### PR TITLE
fix: resolve SSR crash caused by lottie-player and clean up warnings

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,5 +1,11 @@
-import { Button, ShowLottie } from '@/components';
+'use client';
+import dynamic from 'next/dynamic';
+import { Button } from '@/components';
 import { Layout } from '@/containers';
+
+const ShowLottie = dynamic(() => import('@/components/ui/ShowLottie'), {
+  ssr: false,
+});
 
 const NotFound = () => {
   return (

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -13,6 +13,6 @@ export { default as SocialLink } from './socials/SocialLink';
 export { default as AuthorImage } from './ui/AuthorImage';
 export { default as Cursor } from './ui/Cursor';
 export { default as ProjectCard } from './ui/ProjectCard';
-export { default as ShowLottie } from './ui/ShowLottie';
+// export { default as ShowLottie } from './ui/ShowLottie';
 export { default as Sidebar } from './ui/Sidebar';
 export { default as Wrapper } from './ui/Wrapper';

--- a/src/components/skills/Skill.tsx
+++ b/src/components/skills/Skill.tsx
@@ -1,10 +1,14 @@
 'use client';
+import dynamic from 'next/dynamic';
 import { SoftwareSkillType } from '@/lib/types';
 import { getId } from '@/lib/utils/helper';
 
-import { ListItem, ShowLottie, SkillIcon } from '@/components';
-
+import { ListItem, SkillIcon } from '@/components';
 import { motion, MotionProps } from 'framer-motion';
+
+const ShowLottie = dynamic(() => import('@/components/ui/ShowLottie'), {
+  ssr: false,
+});
 
 type Props = {
   lottie?: any;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,11 +2,6 @@
 # yarn lockfile v1
 
 
-"-@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.npmjs.org/-/-/--0.0.1.tgz"
-  integrity sha512-3HfneK3DGAm05fpyj20sT3apkNcvPpCuccOThOPdzz8sY7GgQGe0l93XH9bt+YzibcTIgUAIMoyVJI740RtgyQ==
-
 "@aashutoshrathi/word-wrap@^1.2.3":
   version "1.2.6"
   resolved "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz"


### PR DESCRIPTION
Resolved the following issues during `next dev`:

1. ❌ SSR crash due to `document is not defined`
   - Error trace:
     ⨯ node_modules\@lottiefiles\react-lottie-player\dist\lottie-react.js @ createTag
     ⨯ ReferenceError: document is not defined
   - Cause: `@lottiefiles/react-lottie-player` directly accesses `document`, which breaks server-side rendering.
   - Fix: Removed `ShowLottie` from global exports (components/index.ts) and used `next/dynamic` with `ssr: false` to load it only on the client side in components like `Skill` and `NotFound`.

2. ⚠️ Deprecation warning from Node.js:
   - `(node:XXXX) [DEP0040] DeprecationWarning: The punycode module is deprecated. Please use a userland alternative instead.`
   - Note: This warning is from a Node core dependency, not directly actionable unless upstream packages migrate.

3. ⚠️ Browserslist outdated warning:
   - `Browserslist: caniuse-lite is outdated. Please run: npx update-browserslist-db@latest`
   - Note: This is a reminder to regularly update the `caniuse-lite` DB for accurate browser targeting. Not breaking, but recommended.

Build now compiles successfully:
 ✓ Compiled /page in 1134ms (1204 modules)
