### PR TITLE
refactor: centralize dynamic import of ShowLottie to reduce repetition

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,12 @@
   },
   "[css]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
   // Tailwind CSS Autocomplete, add more if used in projects
-  "tailwindCSS.classAttributes": ["class", "className", "classNames", "containerClassName"],
+  "tailwindCSS.classAttributes": [
+    "class",
+    "className",
+    "classNames",
+    "containerClassName"
+  ],
   "typescript.preferences.importModuleSpecifier": "non-relative",
   "WillLuke.nextjs.hasPrompted": true
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,17 +1,13 @@
 'use client';
-import dynamic from 'next/dynamic';
 import { Button } from '@/components';
 import { Layout } from '@/containers';
-
-const ShowLottie = dynamic(() => import('@/components/ui/ShowLottie'), {
-  ssr: false,
-});
+import { DynamicShowLottie } from '@/components/dynamic/Dynamic';
 
 const NotFound = () => {
   return (
     <Layout className="grid h-screen place-items-center">
       <div className="w-full max-w-xl text-center">
-        <ShowLottie path="/lotties/404.json" className="mx-auto" />
+        <DynamicShowLottie path="/lotties/404.json" className="mx-auto" />
 
         <p className="mt-5 text-3xl capitalize md:text-4xl text-dark-2">
           page not found

--- a/src/components/dynamic/Dynamic.tsx
+++ b/src/components/dynamic/Dynamic.tsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+export const DynamicShowLottie = dynamic(
+  () => import('@/components/ui/ShowLottie'),
+  {
+    ssr: false,
+  }
+);

--- a/src/components/skills/Skill.tsx
+++ b/src/components/skills/Skill.tsx
@@ -1,14 +1,11 @@
 'use client';
-import dynamic from 'next/dynamic';
 import { SoftwareSkillType } from '@/lib/types';
 import { getId } from '@/lib/utils/helper';
 
 import { ListItem, SkillIcon } from '@/components';
 import { motion, MotionProps } from 'framer-motion';
 
-const ShowLottie = dynamic(() => import('@/components/ui/ShowLottie'), {
-  ssr: false,
-});
+import { DynamicShowLottie } from '@/components/dynamic/Dynamic';
 
 type Props = {
   lottie?: any;
@@ -50,7 +47,10 @@ const Skill = ({
         </ul>
       </div>
       {/* Right */}
-      <ShowLottie path={lottie} className="md:min-h-[448px] md:min-w-[448px]" />
+      <DynamicShowLottie
+        path={lottie}
+        className="md:min-h-[448px] md:min-w-[448px]"
+      />
     </motion.div>
   );
 };


### PR DESCRIPTION
@vatsalsinghkv Done! Moved `ShowLottie` dynamic import to a shared module to avoid repetition.

https://github.com/vatsalsinghkv/portfolio-website/pull/19#discussion_r2088102508