### PR TITLE
Light mode issue after refreshing Fixed

### DIFF
--- a/src/components/buttons/DarkModeButton.tsx
+++ b/src/components/buttons/DarkModeButton.tsx
@@ -27,7 +27,7 @@ const DarkModeButton = ({
       {...rest}
     >
       <Icon
-        icon={isDarkMode ? 'carbon:sun' : 'ph:moon'}
+        icon={isDarkMode ? 'ph:moon' : 'carbon:sun'}
         width="26"
         height="26"
       />


### PR DESCRIPTION
The bug has been fixed by inverting the icon logic in the DarkModeButton component. Now, when in dark mode, it displays the moon icon, and in light mode, it displays the sun icon.
issue #28  Fixed